### PR TITLE
arm64 build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ confinement: strict
 type: gadget
 architectures:
   - build-on: amd64
-    run-on: armhf
+    run-on: arm64
 
 parts:
   uboot-pi4:
@@ -21,8 +21,8 @@ parts:
     plugin: nil
     override-build: |
       git apply -v ../../../uboot4.patch
-      make rpi_4_32b_defconfig
-      ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- make -j4
+      make rpi_4_defconfig
+      ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- make -j4
       mkdir -p $SNAPCRAFT_PART_INSTALL/boot-assets
       cp -av u-boot.bin $SNAPCRAFT_PART_INSTALL/boot-assets/uboot4.bin
       tools/mkenvimage -r -s 131072 -o $SNAPCRAFT_PART_INSTALL/uboot.env ../../../uboot.env.in
@@ -36,7 +36,8 @@ parts:
       - html2text
       - libpython2.7-dev
       - python-minimal
-      - gcc-arm-linux-gnueabihf
+      - on amd64:
+        - gcc-aarch64-linux-gnu:amd64
   boot-firmware:
     plugin: nil
     source: .

--- a/uboot4.patch
+++ b/uboot4.patch
@@ -1,7 +1,7 @@
-diff --git a/configs/rpi_4_32b_defconfig b/configs/rpi_4_32b_defconfig
+diff --git a/configs/rpi_4_defconfig b/configs/rpi_4_defconfig
 index b71a1473..c7b75bd0 100644
---- a/configs/rpi_4_32b_defconfig
-+++ b/configs/rpi_4_32b_defconfig
+--- a/configs/rpi_4_defconfig
++++ b/configs/rpi_4_defconfig
 @@ -38,3 +38,4 @@ CONFIG_SYS_WHITE_ON_BLACK=y
  CONFIG_CONSOLE_SCROLL_LINES=10
  CONFIG_PHYS_TO_BUS=y


### PR DESCRIPTION
Thanks for putting this together! We were able to get our snaps up on the Pi4 rather quickly.

We're now trying to get this gadget and the kernel snap working on arm64.

With this patch we can build the and image with the arm64, but the device fails to boot - HDMI 0 is active, but nothing is displayed.

Does anyone have an idea what we're missing or ideas on how to debug?

For reference, our [model assertion is here](https://gist.github.com/j-white/d7744cc77d6729bd9a7dbb97a3f1cd7e) and our [kernel snap patch is here](https://github.com/j-white/linux-raspberrypi-org/commit/711fd1bb01246f124c9b4d9a1338e81a22341349).

